### PR TITLE
Load dependencies

### DIFF
--- a/symbol-navigation-hydra.el
+++ b/symbol-navigation-hydra.el
@@ -37,6 +37,9 @@
 
 ;;; Code:
 
+(require 'hydra)
+(require 'auto-highlight-symbol)
+
 (defgroup symbol-navigation-hydra nil
   "The Symbol Navigation Hydra"
   :group 'convenience


### PR DESCRIPTION
Fix following byte-compile warnings

```
symbol-navigation-hydra.el:83:1:Warning: ‘"n"’ is a malformed function
symbol-navigation-hydra.el:83:1:Warning: ‘"N"’ is a malformed function
symbol-navigation-hydra.el:83:1:Warning: ‘"p"’ is a malformed function
symbol-navigation-hydra.el:83:1:Warning: ‘"r"’ is a malformed function
symbol-navigation-hydra.el:83:1:Warning: ‘"R"’ is a malformed function
symbol-navigation-hydra.el:83:1:Warning: ‘"z"’ is a malformed function
symbol-navigation-hydra.el:83:1:Warning: ‘"e"’ is a malformed function
symbol-navigation-hydra.el:83:1:Warning: ‘"s"’ is a malformed function
symbol-navigation-hydra.el:83:1:Warning: ‘"f"’ is a malformed function
symbol-navigation-hydra.el:83:1:Warning: ‘"g"’ is a malformed function
symbol-navigation-hydra.el:83:1:Warning: ‘"q"’ is a malformed function
symbol-navigation-hydra.el:83:11:Warning: reference to free variable
    ‘sn-hydra’
symbol-navigation-hydra.el:83:11:Warning: ‘:hint’ called as a function
symbol-navigation-hydra.el:92:8:Warning: reference to free variable
    ‘symbol-navigation-hydra-move-point-one-symbol-forward’
symbol-navigation-hydra.el:93:8:Warning: reference to free variable
    ‘symbol-navigation-hydra-move-point-one-symbol-backward’
symbol-navigation-hydra.el:95:8:Warning: reference to free variable
    ‘ahs-change-range’
symbol-navigation-hydra.el:96:8:Warning: reference to free variable
    ‘symbol-navigation-hydra-back-to-start’
symbol-navigation-hydra.el:98:8:Warning: reference to free variable
    ‘symbol-navigation-hydra-engage-iedit’
symbol-navigation-hydra.el:99:8:Warning: reference to free variable
    ‘symbol-navigation-hydra-swoop’

In symbol-navigation-hydra-header:
symbol-navigation-hydra.el:198:33:Warning: reference to free variable
    ‘ahs-overlay-list’
symbol-navigation-hydra.el:200:40:Warning: reference to free variable
    ‘ahs-current-overlay’
symbol-navigation-hydra.el:206:25:Warning: reference to free variable
    ‘ahs-plugin-defalt-face’
symbol-navigation-hydra.el:207:25:Warning: reference to free variable
    ‘ahs-plugin-whole-buffer-face’
symbol-navigation-hydra.el:208:25:Warning: reference to free variable
    ‘ahs-plugin-bod-face’

In symbol-navigation-hydra-get-occurrences-within-range:
symbol-navigation-hydra.el:263:29:Warning: reference to free variable
    ‘ahs-case-fold-search’

In symbol-navigation-hydra-get-occurrence-index:
symbol-navigation-hydra.el:321:31:Warning: reference to free variable
    ‘ahs-current-overlay’
```