### PR TITLE
Introduce multiple cursor functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,20 @@ With your cursor anywhere on a symbol (no need to select it), bring up the hydra
     * _r_ selects another range. There are only three, so at most you need to hit it twice.
     * _z_ vertically centers the current line. This is like the Emacs command `recenter-top-bottom` -
           usually `C-l` - but within the hydra.
+* Multi
+    * _f_ drops a cursor at the current location, and moves forward to the next occurrence of the symbol
+          within the range. After this, you will have at least two cursors active.
+    * _b_ drops a cursor at the current location, and moves backward to the previous occurrence of the symbol
+          within the range. After this, you will have at least two cursors active.
+    * _e_ exits the hydra and preserves all cursors. This is the way to exit when they want to exit the
+          hydra and start editing your buffer again, but with the multiple cursors active. All other ways
+          of exiting the hydra will clear the cursors.
+    * _a_ places cursors at every instance of the symbol in the range.
+    * _s_ activates [Helm Swoop](https://github.com/emacsorphanage/helm-swoop), with the current symbol
+          as the search query. This is not range-aware.
 * Search
-    * _f_ and _g_ search for the symbol in the current directory and Projectile project, respectively.
+    * _d_ and _g_ search for the symbol in the current directory and Projectile project, respectively.
                   This is not a function of the current range.
-* Multi-occurrence
-    * _e_ places multiple cursors on every instance of the symbol. This is range-aware.
-    * _s_ activates [Helm Swoop](https://github.com/emacsorphanage/helm-swoop) on the symbol. This
-          is not range-aware.
 
 ## Setup
 
@@ -48,18 +55,17 @@ Alternately, clone a) this repo b) [hydra](https://github.com/abo-abo/hydra) c) 
 (package! symbol-navigation-hydra :recipe
   '(:host github
     :repo "bgwines/symbol-navigation-hydra"))
-
 ```
 
 ### Installing (additional functionality)
 
 By default, only the navigation functionality is enabled. The remaining heads are disabled so as to not bloat the user's setup by installing a bunch of dependencies when installing this package. The following packages are optional, but enable features that are disabled otherwise:
 
-* [`iedit`](https://github.com/victorhge/iedit)
 * [`helm-swoop`](https://github.com/emacsorphanage/helm-swoop)
 * [`helm-ag`](https://github.com/emacsorphanage/helm-ag)
     * [The Silver Searcher](https://github.com/ggreer/the_silver_searcher)
 * [`projectile`](https://github.com/bbatsov/projectile)
+* [`multiple-cursors`](https://github.com/magnars/multiple-cursors.el)
 
 ### Activating
 
@@ -86,6 +92,10 @@ By default, only the navigation functionality is enabled. The remaining heads ar
 
 ;; Disable symbol highlighting when the hydra is not active (yes, this is a hack 😅).
 (setq-default ahs-idle-interval 999999999.0)
+
+;; Defaults for multiple cursor behavior
+(setq-default mc/always-repeat-command t)
+(setq-default mc/always-run-for-all t)
 
 ;; Many - but not all - languages are supported by default. You'll probably get pretty good
 ;; behavior by just opting one in if it's not already there.


### PR DESCRIPTION
Introduces several new heads, all of which are range-aware. The old _f_ head (helm ag searches the current folder) has been renamed to _d_ ('d' for "directory") to make room for the new head:
* _f_: mark & next ('f' for "forward", but described as "next" for symmetry with the _n_ head's name)
* _b_: mark & prev ('b' for "backward", but described as "prev" for symmetry with the _p_ head's name)
* _a_: mark all. This replaces `iedit`, which is nice because
    a) now we can remove that dependency (and replace it with something more standard)
    b) it had no visual indication of cursors or the symbols that would be affected by edits
    c) it was not range-aware
* _e_: edit marks. This is the head that the user should activate when they want to exit the hydra and start editing their file again, but with the multiple cursors active. `C-g` and _q_ both exit the hydra but clean up all the cursors.

_f_, _b_, and _a_ won't place redundant cursors -- this handles the situation where - for example - the user enters 'b', then 'b', and then wants to go forward, but hits 'f' instaed of 'n'.

The header now displays the number of multiple cursors active since the user's modeline my not display that info.

Regarding the `save-excursion` in `symbol-navigation-hydra-mark-all`... https://www.gnu.org/software/emacs/manual/html_node/eintr/save_002dexcursion.html doesn't say whether it handles exceptions but I included it in case it is nice and does, restoring the original `point` location in the exception-handling.

### MELPA checks

☑️  My elisp byte-compiles cleanly
☑️  M-x checkdoc is happy with my docstrings
✖️  I've used the latest version of package-lint to check for packaging issues, and addressed its feedback

I get the following errors:

```
7:23: error: Package auto-highlight-symbol is not installable.
7:54: error: Package hydra is not installable.
7:86: error: Package multiple-cursors is not installable.
```

This is referring to the `Package-Requires` line:

https://github.com/bgwines/symbol-navigation-hydra/pull/11/files#diff-f85f19de793c3e8152841193a7c46fc5R7

However, the latest MELPA build lists the dependencies (https://melpa.org/#/symbol-navigation-hydra) and they have links to those versions of the packages, so it was clearly happy with it as of 72982a7. When I run it on 72982a7, it fails with similar errors. Sooooooooo I think we're probably fine.